### PR TITLE
limit the version of dask distributed

### DIFF
--- a/dask_k8/default_configs.py
+++ b/dask_k8/default_configs.py
@@ -1,7 +1,7 @@
 
 scheduler_pod_spec_yaml = """
   containers:
-    - image: daskdev/dask:latest
+    - image: daskdev/dask:1.2.0
       command: ["sh", "-c"]
       args:
         - dask-scheduler --port 8786 --bokeh-port 8787
@@ -18,7 +18,7 @@ scheduler_pod_spec_yaml = """
 
 worker_pod_spec_yaml = """
   containers:
-    - image: daskdev/dask:latest
+    - image: daskdev/dask:1.2.0
       args: [dask-worker, $(DASK_SCHEDULER_ADDRESS), --nthreads, '1', --no-bokeh, --memory-limit, 4GB, --death-timeout, '60']
       imagePullPolicy: Always
       name: dask-worker

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='dask-k8',
             'Programming Language :: Python :: 3.6',
       ],
       install_requires=[
-          'distributed>=1.27',
+          'distributed>=1.27,<2.0.0',
           'requests>=2.20',
           'kubernetes>=9.0',
       ])


### PR DESCRIPTION
Hello Benoit,
`distributed` now requires `dask>=2`, but dask-k8 currently breaks with this new version.
Workers are created, but then it is not possible to make the dask client. With a lower version of dask it works. Below is the error message:

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~/.local/share/virtualenvs/impresso-pyindexation-7yA7z983/lib/python3.6/site-packages/IPython/core/formatters.py in __call__(self, obj)
    700                 type_pprinters=self.type_printers,
    701                 deferred_pprinters=self.deferred_printers)
--> 702             printer.pretty(obj)
    703             printer.flush()
    704             return stream.getvalue()

~/.local/share/virtualenvs/impresso-pyindexation-7yA7z983/lib/python3.6/site-packages/IPython/lib/pretty.py in pretty(self, obj)
    400                         if cls is not object \
    401                                 and callable(cls.__dict__.get('__repr__')):
--> 402                             return _repr_pprint(obj, self, cycle)
    403 
    404             return _default_pprint(obj, self, cycle)

~/.local/share/virtualenvs/impresso-pyindexation-7yA7z983/lib/python3.6/site-packages/IPython/lib/pretty.py in _repr_pprint(obj, p, cycle)
    695     """A pprint that just redirects to the normal repr function."""
    696     # Find newlines and replace them with p.break_()
--> 697     output = repr(obj)
    698     for idx,output_line in enumerate(output.splitlines()):
    699         if idx:

~/.local/share/virtualenvs/impresso-pyindexation-7yA7z983/lib/python3.6/site-packages/distributed/client.py in __repr__(self)
    771             workers = info.get("workers", {})
    772             nworkers = len(workers)
--> 773             nthreads = sum(w["nthreads"] for w in workers.values())
    774             return "<%s: scheduler=%r processes=%d cores=%d>" % (
    775                 self.__class__.__name__,

~/.local/share/virtualenvs/impresso-pyindexation-7yA7z983/lib/python3.6/site-packages/distributed/client.py in <genexpr>(.0)
    771             workers = info.get("workers", {})
    772             nworkers = len(workers)
--> 773             nthreads = sum(w["nthreads"] for w in workers.values())
    774             return "<%s: scheduler=%r processes=%d cores=%d>" % (
    775                 self.__class__.__name__,

KeyError: 'nthreads'
```
